### PR TITLE
"fixed" hardcoded websocket url issue

### DIFF
--- a/lambdaface_face/src/Components/HomePage.js
+++ b/lambdaface_face/src/Components/HomePage.js
@@ -93,7 +93,7 @@ class HomePage extends React.Component {
       console.log('Brower doesn\'t support web sockets');
     }
 
-    const connection = new WebSocket('ws://localhost:5000/ws');
+    const connection = new WebSocket(`ws://${process.env.REACT_APP_WSURL}/ws`);
     connection.onopen = () => {
       // console.log('connection opened');
       // console.log(this.state.user);

--- a/server/api/controllers/webSockets.js
+++ b/server/api/controllers/webSockets.js
@@ -80,7 +80,7 @@ const webSocketConnect = (ws, req) => {
   })
 
   ws.on('close', connection => {
-    console.log(`${new Date()} Peer ${connection.remoteAddress} disconnected.`);
+    console.log(`${new Date()} Peer ${userId} disconnected.`);
     delete connectedUsers[userId];
   });
 }


### PR DESCRIPTION
# Description
websocket url in HomePage component used hard-coded url, is now an env variable, which should look something like:
REACT_APP_URL="http://localhost:5000/"
REACT_APP_WSURL="localhost:5000"

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] renders without crashing
- [x] notifications appear as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
