### PR TITLE
Added ability to click notifications

### DIFF
--- a/lambdaface_face/src/Components/TopBar.js
+++ b/lambdaface_face/src/Components/TopBar.js
@@ -11,7 +11,7 @@ export default props => {
     <div className="top-bar">
       <img src={LambdaLogo} alt="logo" className="top-bar__logo" />
       <Search className="top-bar__search" onSubmit={props.changeCurrentCategory} />
-      <Notifications notifications={props.notifications} clearNotifications={props.clearNotifications} />
+      <Notifications notifications={props.notifications} clearNotifications={props.clearNotifications} changeCurrentCategory={props.changeCurrentCategory} />
       <div className="top-bar__user-button">
         <Button onClick={props.changeCurrentCategory(["User Settings", null])}>
           <img src={`${profilePic}?${props.imageHash}}`} alt="profile" className="top-bar__user-image" />

--- a/lambdaface_face/src/Components/TopBar/Notifications.js
+++ b/lambdaface_face/src/Components/TopBar/Notifications.js
@@ -10,7 +10,7 @@ const NoticeMeSenpi = (numb) => (
   </div>
 );
 
-const NotificationsMenu = (notifications, clearNotifications) => {
+const NotificationsMenu = (notifications, clearNotifications, changeCurrentCategory) => {
   const grammarParser = (type) => {
     switch(type) {
       case 'comment':
@@ -34,17 +34,18 @@ const NotificationsMenu = (notifications, clearNotifications) => {
         <span>notifications</span>
         <button onClick={clearNotifications}>clear</button>
       </div>
-      { notifications.map(({ sourceFirstName, sourceLastName, sourceProfilePicture, postContent, notificationType }, i) => {
+      { notifications.map((post, i) => {
+        const { firstName, lastName, profilePicture, content, notificationType } = post;
         const [ grammar, parentType ] = grammarParser(notificationType);
         return (
-          <div className={"notifications-menu__item notifications-menu__item" + (i % 2 ? "--light" : "--dark")}>
+          <div onClick={changeCurrentCategory(["PostPage", null], post)} className={"notifications-menu__item notifications-menu__item" + (i % 2 ? "--light" : "--dark")} key={post.id}>
             <div className="notifications-menu__item__user">
-              <img className="notifications-menu__item__user-image" src={sourceProfilePicture} alt={`${sourceFirstName} ${sourceLastName}`} />
-              <strong>{`${sourceFirstName} ${sourceLastName}`}</strong>
+              <img className="notifications-menu__item__user-image" src={profilePicture} alt={`${firstName} ${lastName}`} />
+              <strong>{`${firstName} ${lastName}`}</strong>
             </div>
             <p className="notifications-menu__item__text">
               { grammar } your { parentType }
-              <strong> { contentParser(postContent) }</strong>
+              <strong> { contentParser(content) }</strong>
             </p>
           </div>
         );
@@ -120,7 +121,7 @@ class Notifications extends React.Component {
           alt="notifications icon"  
         />
         { this.state.displayNotificationsMenu
-          ? NotificationsMenu(notifications, this.clearNotifications)
+          ? NotificationsMenu(notifications, this.clearNotifications, this.props.changeCurrentCategory)
           : ''
         }
       </div>

--- a/lambdaface_face/src/Styles/css/index.css
+++ b/lambdaface_face/src/Styles/css/index.css
@@ -409,10 +409,18 @@ body {
   font-weight: bold;
 }
 .notifications-menu__item--dark {
-  background-color: #EEEEEE;
+  background-color: #fbfcfd;
+}
+.notifications-menu__item--dark:hover {
+  cursor: pointer;
+  background-color: #eaeff5;
 }
 .notifications-menu__item--light {
-  background-color: white;
+  background-color: #ffffff;
+}
+.notifications-menu__item--light:hover {
+  cursor: pointer;
+  background-color: #f2f2f2;
 }
 .notifications-menu__item__text > strong {
   font-weight: bold;

--- a/lambdaface_face/src/Styles/less/topBar.less
+++ b/lambdaface_face/src/Styles/less/topBar.less
@@ -106,10 +106,18 @@
     }
     padding: 10px;
     &--dark {
-      background-color: #EEEEEE;
+      background-color: rgb(251, 252, 253);
+      &:hover {
+        cursor: pointer;
+        background-color: darken(rgb(251, 252, 253), 5%);
+      }
     }
     &--light {
-      background-color: white;
+      background-color: rgb(255, 255, 255);
+      &:hover {
+        cursor:pointer;
+        background-color: darken(rgb(255, 255, 255), 5%);
+      }
     }
     &__text {
       & > strong {

--- a/server/api/controllers/webSockets.js
+++ b/server/api/controllers/webSockets.js
@@ -4,6 +4,8 @@ const knex = require('../../database/db.js');
 
 const connectedUsers = {};
 
+const { _joinVote } = require('./helpers.js')
+
 const storeNotification = (obj) => {
   // console.log('creating new notification...');
   const id = uuidv4();
@@ -35,19 +37,23 @@ const sendNotifications = (userId) => {
   fetch
     .join('user', 'notification.sourceId', '=', 'user.id')
     .join('post', 'notification.postId', '=', 'post.id')
+    .leftJoin( ..._joinVote('post', 'INC') )
+    .leftJoin( ..._joinVote('post', 'DEC', 'dv') )
     .select(
-      'post.categoryId as postCategoryId',
-      'post.commentCount as postCommentCount',
-      'post.content as postContent',
-      'post.createdAt as postCreatedAt',
-      'post.id as postId',
-      'post.updatedAt as postUpdatedAt',
-      'post.userId as postUserId',
-      'post.viewCount as postViewCount',
-      'user.firstName as sourceFirstName',
-      'user.lastName as sourceLastName',
-      'user.profilePicture as sourceProfilePicture',
-      'notification.type as notificationType'
+      'post.categoryId as categoryId',
+      'post.commentCount as commentCount',
+      'post.content as content',
+      'post.createdAt as createdAt',
+      'post.id as id',
+      'post.updatedAt as updatedAt',
+      'post.userId as userId',
+      'post.viewCount as viewCount',
+      'user.firstName as firstName',
+      'user.lastName as lastName',
+      'user.profilePicture as profilePicture',
+      'notification.type as notificationType',
+      'v.upvotes as upvotes',
+      'dv.downvotes as downvotes'
     )
     .then(response => 
       // delete sent notifications from DB


### PR DESCRIPTION
# Description
changed webSockets query to match post properties, so can pass post to notifications.
Notifications can now change category to "Post Page" with given post info.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, but not tested (may need new tests)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] clicking on notification takes use to given post
- [x] renders without crashing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
